### PR TITLE
Looping fix

### DIFF
--- a/src/Screens/FinalLevelClearedScreen.java
+++ b/src/Screens/FinalLevelClearedScreen.java
@@ -1,0 +1,41 @@
+package Screens;
+
+import Engine.Config;
+import Engine.GraphicsHandler;
+import Engine.Screen;
+import Engine.ScreenManager;
+import SpriteFont.SpriteFont;
+
+import java.awt.*;
+
+// This class is for the final level cleared screen. After this screen, the program
+// goes back to the main menu instead of starting another level.
+public class FinalLevelClearedScreen extends Screen 
+{
+    protected SpriteFont winMessage;
+    protected Color backgroundColor;
+
+    public FinalLevelClearedScreen() 
+    {
+    	backgroundColor = new Color(21, 149, 62);
+    }
+
+    @Override
+    public void initialize() 
+    {
+        winMessage = new SpriteFont("You completed all of the levels!", 180, 270, "Comic Sans", 30, Color.white);
+    }
+
+    @Override
+    public void update() 
+    {
+
+    }
+
+    // Draws the green background and white message to the screen.
+    public void draw(GraphicsHandler graphicsHandler) 
+    {
+        graphicsHandler.drawFilledRectangle(0, 0, Config.WIDTH, Config.HEIGHT, backgroundColor);
+        winMessage.draw(graphicsHandler);
+    }
+}

--- a/src/Screens/PlayLevelScreen.java
+++ b/src/Screens/PlayLevelScreen.java
@@ -32,6 +32,7 @@ public class PlayLevelScreen extends Screen implements PlayerListener {
 	protected Stopwatch screenTimer = new Stopwatch();
 	protected LevelClearedScreen levelClearedScreen;
 	protected LevelLoseScreen levelLoseScreen;
+	protected FinalLevelClearedScreen finalClearScreen;
 	protected SpriteFont pauseLabel;
 	protected LevelSelectScreen levelSelectScreen;
 	protected int levelNum = 0;
@@ -127,8 +128,19 @@ public class PlayLevelScreen extends Screen implements PlayerListener {
 			break;
 		// if level has been completed, bring up level cleared screen
 		case LEVEL_COMPLETED:
-			levelClearedScreen = new LevelClearedScreen();
-			levelClearedScreen.initialize();
+			// Check to see if the level number is less than the index of the last level
+			// In this case, the last level is 5, which has an index of 4.
+			if(levelNum < 4)
+			{
+				levelClearedScreen = new LevelClearedScreen();
+				levelClearedScreen.initialize();
+			}
+			// If it is the final level, use the final clear screen instead.
+			else
+			{
+				finalClearScreen = new FinalLevelClearedScreen();
+				finalClearScreen.initialize();
+			}
 			screenTimer.setWaitTime(2500);
 			playLevelScreenState = PlayLevelScreenState.LEVEL_WIN_MESSAGE;
 			break;
@@ -194,7 +206,17 @@ public class PlayLevelScreen extends Screen implements PlayerListener {
 			player.draw(graphicsHandler);
 			break;
 		case LEVEL_WIN_MESSAGE:
-			levelClearedScreen.draw(graphicsHandler);
+			// Check to see if the level number is less than the index of the last level
+			// In this case, the last level is 5, which has an index of 4.
+			if(levelNum < 4)
+			{
+				levelClearedScreen.draw(graphicsHandler);
+			}
+			// If it is the final level, draw the final clear screen instead.
+			else
+			{
+				finalClearScreen.draw(graphicsHandler);
+			}
 			break;
 		case LEVEL_LOSE_MESSAGE:
 			levelLoseScreen.draw(graphicsHandler);


### PR DESCRIPTION
I implemented the fix for the bug that caused the final level (level 5) to loop infinitely when completed. If the player hits the gold box at the end of the final level now, they are brought back to the main menu. They are also presented with a unique green level cleared screen with a different message when clearing the final level.

Please verify that this feature is implemented correctly using Test Case TC-04 (Level 5 Loop Verification).